### PR TITLE
Add Resume PDF to Navigation

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -6,6 +6,11 @@
             </a>
         </li>
         <li>
+            <a href="https://docs.google.com/document/d/19nkYd8pPs7NyUVY3u2nL9SeM9PIx205Gts2062LRjZM/export?format=pdf">
+                Resume
+            </a>
+        </li>
+        <li>
             <a href="/contact" {% if page.url == "/contact/" %}class="active"{% endif %}>
                 Contact
             </a>


### PR DESCRIPTION
This adds a shared PDF export URL of Google Doc version of resume, to the navigation menu.